### PR TITLE
to_python_type bugfix

### DIFF
--- a/test/test_to_python_type.py
+++ b/test/test_to_python_type.py
@@ -63,6 +63,7 @@ class TestTable(BaseClass):
         self.run_test("{1, 2, a = 3}", {1: 1, 2: 2, "a": 3})
         self.run_test("{1, 2, 3, [4] = 4}", [1, 2, 3, 4])
         self.run_test("{1, 2, [5] = 5}", {1: 1, 2: 2, 5: 5})
+        self.run_test("{[0] = 1, 1, 2}", {0: 1, 1: 1, 2: 2})
 
     def test_explicit_field(self):
         self.run_test('{["foo"] = 1, [2] = 2}', {"foo": 1, 2: 2})

--- a/tumfl/to_python_type.py
+++ b/tumfl/to_python_type.py
@@ -111,7 +111,8 @@ class ToPythonType(BasicWalker[Retype]):
         # pylint: disable=consider-iterating-dictionary
         if len(results) > 0 and all(isinstance(val, int) for val in results.keys()):
             max_key: int = max(results.keys())  # type: ignore
-            if all(key in results for key in range(1, max_key + 1)):
+            min_key: int = min(results.keys())  #type: ignore
+            if min_key == 1 and all(key in results for key in range(1, max_key + 1)):
                 return [results[key] for key in range(1, max_key + 1)]
         return results
 

--- a/tumfl/to_python_type.py
+++ b/tumfl/to_python_type.py
@@ -111,7 +111,7 @@ class ToPythonType(BasicWalker[Retype]):
         # pylint: disable=consider-iterating-dictionary
         if len(results) > 0 and all(isinstance(val, int) for val in results.keys()):
             max_key: int = max(results.keys())  # type: ignore
-            min_key: int = min(results.keys())  #type: ignore
+            min_key: int = min(results.keys())  # type: ignore
             if min_key == 1 and all(key in results for key in range(1, max_key + 1)):
                 return [results[key] for key in range(1, max_key + 1)]
         return results


### PR DESCRIPTION
Fixes a bug where to_python_type would discard keys <= 0, and concatenate the other keys into a list