### PR TITLE
Actually use minified style

### DIFF
--- a/tumfl/__main__.py
+++ b/tumfl/__main__.py
@@ -8,10 +8,8 @@ from typing import Optional
 from watchdog.events import EVENT_TYPE_CLOSED, FileSystemEvent, FileSystemEventHandler
 from watchdog.observers import Observer
 
-from tumfl.formatter import MinifiedStyle
-
 try:
-    from watchdog.events import EVENT_TYPE_OPENED
+    from watchdog.events import EVENT_TYPE_OPENED  # pylint: disable=ungrouped-imports
 except ImportError:
     EVENT_TYPE_OPENED = "opened"  # type: ignore
 
@@ -20,6 +18,7 @@ from tumfl.AST import ASTNode
 from tumfl.config import Config, parse_config
 from tumfl.dependency_resolver import resolve_recursive
 from tumfl.error import TumflError
+from tumfl.formatter import MinifiedStyle
 
 
 class RunConfig:


### PR DESCRIPTION
When running as executable, actually use the minified style.