### PR TITLE
Add local minification

### DIFF
--- a/test/minifier/test_block_optimization.py
+++ b/test/minifier/test_block_optimization.py
@@ -1,6 +1,8 @@
-from tumfl import parse, format
-from tumfl.minifier.block_optimization import Optimize
 import unittest
+
+from tumfl import format, parse
+from tumfl.minifier.block_optimization import Optimize
+
 
 class TestBlockOptimization(unittest.TestCase):
     def run_test(self, code: str, expected: str):

--- a/test/minifier/test_block_optimization.py
+++ b/test/minifier/test_block_optimization.py
@@ -1,0 +1,40 @@
+from tumfl import parse, format
+from tumfl.minifier.block_optimization import Optimize
+import unittest
+
+class TestBlockOptimization(unittest.TestCase):
+    def run_test(self, code: str, expected: str):
+        ast = parse(code)
+        Optimize()(ast)
+        self.assertMultiLineEqual(format(ast), format(parse(expected)))
+
+    def test_local_optimization(self):
+        code = """
+        local a = 1
+        local b = 2
+        local c = a + b
+        """
+        expected = """
+        local a, b,c
+        a = 1
+        b = 2
+        c = a + b
+        """
+        self.run_test(code, expected)
+
+    def test_def_only_local_assigns(self):
+        code = """
+        local a, b
+        a = 1
+        b = 2
+        local c = a + b
+        foo(c)
+        """
+        expected = """
+        local a, b, c
+        a = 1
+        b = 2
+        c = a + b
+        foo(c)
+        """
+        self.run_test(code, expected)

--- a/test/minifier/test_integration.py
+++ b/test/minifier/test_integration.py
@@ -1,6 +1,6 @@
 import unittest
 
-from tumfl import minify, parse, format
+from tumfl import format, minify, parse
 
 
 class TestMinifier(unittest.TestCase):
@@ -16,13 +16,35 @@ class TestMinifier(unittest.TestCase):
         minify(ast)
         formatted_code = format(ast)
         expected_code = """
+        local b, c
         a = foo.bar
-        local b = a()
-        local c = a()
+        b = a()
+        c = a()
         a(b, c)
         """
-        self.assertEqual(formatted_code, format(parse(expected_code)))
+        self.assertMultiLineEqual(formatted_code, format(parse(expected_code)))
+
+    def test_local_assign(self):
+        code = """
+        b = 2
+        local a = 1
+        local b = b
+        local c = a + b
+        foo(c)
+        """
+        ast = parse(code)
+        minify(ast)
+        formatted_code = format(ast)
+        expected_code = """
+        local b, c, d
+        a = 2
+        b = 1
+        c = a
+        d = b + c
+        foo(d)
+        """
+        self.assertMultiLineEqual(formatted_code, format(parse(expected_code)))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tumfl/minifier/block_optimization.py
+++ b/tumfl/minifier/block_optimization.py
@@ -1,10 +1,13 @@
-from tumfl.AST import Block, LocalAssign, Assign, Name
+from tumfl.AST import Assign, Block, LocalAssign, Name
 from tumfl.basic_walker import NoneWalker
+
 
 class Optimize(NoneWalker):
     def visit_Block(self, node: Block) -> None:
         super().visit_Block(node)
-        local_assigns: list[LocalAssign] = [stmt for stmt in node.statements if isinstance(stmt, LocalAssign)]
+        local_assigns: list[LocalAssign] = [
+            stmt for stmt in node.statements if isinstance(stmt, LocalAssign)
+        ]
         if len(local_assigns) > 1:
             new_assign = LocalAssign(local_assigns[0].token, [], [])
             for assign in local_assigns:

--- a/tumfl/minifier/block_optimization.py
+++ b/tumfl/minifier/block_optimization.py
@@ -1,0 +1,19 @@
+from tumfl.AST import Block, LocalAssign, Assign, Name
+from tumfl.basic_walker import NoneWalker
+
+class Optimize(NoneWalker):
+    def visit_Block(self, node: Block) -> None:
+        super().visit_Block(node)
+        local_assigns: list[LocalAssign] = [stmt for stmt in node.statements if isinstance(stmt, LocalAssign)]
+        if len(local_assigns) > 1:
+            new_assign = LocalAssign(local_assigns[0].token, [], [])
+            for assign in local_assigns:
+                new_assign.variable_names.extend(assign.variable_names)
+            node.statements.insert(0, new_assign)
+            for assign in local_assigns:
+                if assign.expressions:
+                    targets: list[Name] = [name.name for name in assign.variable_names]
+                    normal_assign = Assign(assign.token, targets, assign.expressions)
+                    assign.replace(normal_assign)
+                else:
+                    assign.remove()

--- a/tumfl/minifier/minify.py
+++ b/tumfl/minifier/minify.py
@@ -1,4 +1,5 @@
 from tumfl.AST import ASTNode, Chunk
+from tumfl.minifier.block_optimization import Optimize
 from tumfl.minifier.resolve_indexes import Resolve
 from tumfl.minifier.shorten_names import GetNames, remove_unused_names
 from tumfl.minifier.simplify_expressions import Simplify
@@ -14,5 +15,6 @@ def minify(ast: ASTNode) -> None:
     assert isinstance(ast, Chunk)
     replacements = r.current_scope.collect_replacements()
     full_replace(ast, replacements)
+    Optimize()(ast)
     # CombineLocal()(ast) combine_local still contains flaws
     Simplify()(ast)

--- a/tumfl/minifier/shorten_names.py
+++ b/tumfl/minifier/shorten_names.py
@@ -147,16 +147,25 @@ class GetNames(NoneWalker):
             self.read_var(node)
 
     def visit_Assign(self, node: Assign) -> None:
+        for expr in node.expressions:
+            self.visit(expr)
         self.set_preserve(node)
         for target in node.targets:
             self.add_var_opt(target, True)
         self.preserve = False
-        super().visit_Assign(node)
+        for target in node.targets:
+            self.visit(target)
 
     def visit_LocalAssign(self, node: LocalAssign) -> None:
+        if node.expressions:
+            for expr in node.expressions:
+                self.visit(expr)
         for name in node.variable_names:
             self.add_var_opt(name.name)
-        super().visit_LocalAssign(node)
+        for var in node.variable_names:
+            self.visit(var.name)
+            if var.attribute:
+                self.visit(var.attribute)
 
     def visit_IterativeFor(self, node: IterativeFor) -> None:
         self.push_outer_scope()

--- a/tumfl/minifier/shorten_names.py
+++ b/tumfl/minifier/shorten_names.py
@@ -157,6 +157,7 @@ class GetNames(NoneWalker):
             self.visit(target)
 
     def visit_LocalAssign(self, node: LocalAssign) -> None:
+        # pylint: disable=duplicate-code
         if node.expressions:
             for expr in node.expressions:
                 self.visit(expr)


### PR DESCRIPTION
This adds more capabilities, if multiple local assigns are in the same block, collecting the local declarations at the top, and then using regular assigns afterward.

Also fixes issues with order of operation of assigns in GetNames