### PR TITLE
Fix Parenthesis for function calls and vararg.

### DIFF
--- a/test/test_formatter.py
+++ b/test/test_formatter.py
@@ -244,6 +244,9 @@ class TestFormatter(unittest.TestCase):
         exp = Parser("...")._parse_exp()
         expected = ["..."]
         self.assertEqual(self.normal.visit(exp), expected)
+        exp = Parser("(...)")._parse_exp()
+        expected = ["(", "...", ")"]
+        self.assertEqual(self.normal.visit(exp), expected)
 
     def test_While(self):
         stmt = Parser("while i do a=b end")._parse_while()
@@ -430,6 +433,9 @@ class TestFormatter(unittest.TestCase):
         exp = Parser("a(1)")._parse_exp()
         expected = ["a", "(", "1", ")"]
         self.assertEqual(self.normal.visit(exp), expected)
+        exp = Parser("(a(1))")._parse_exp()
+        expected = ["(", "a", "(", "1", ")", ")"]
+        self.assertEqual(self.normal.visit(exp), expected)
 
     def test_ExpFunctionDefinition(self):
         exp = Parser("function (a,b)a=b end")._parse_exp()
@@ -451,6 +457,9 @@ class TestFormatter(unittest.TestCase):
     def test_ExpMethodInvocation(self):
         exp = Parser("a:b(1)")._parse_exp()
         expected = ["a", ":", "b", "(", "1", ")"]
+        self.assertEqual(self.normal.visit(exp), expected)
+        exp = Parser("(a:b(1))")._parse_exp()
+        expected = ["(", "a", ":", "b", "(", "1", ")", ")"]
         self.assertEqual(self.normal.visit(exp), expected)
 
     def test_LocalFunctionDefinition(self):

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -231,6 +231,14 @@ class TestParser(unittest.TestCase):
         self.assertEqual(parser._parse_var(), expected_tree_f)
         self.assertEqual(len(parser.context_hints), 0)
         self.assertEqual(parser.current_token, EOF_TOKEN)
+        parser = Parser("((2)(1))")
+        expected_tree_pf = ExpFunctionCall(
+            Token(TokenType.L_PAREN, "(", 0, 0),
+            self.parse_number("2"),
+            [self.parse_number("1")],
+            has_parentheses=True,
+        )
+        self.assertEqual(parser._parse_var(), expected_tree_pf)
         parser = Parser("a:b()")
         expected_tree_m = ExpMethodInvocation(
             Token(TokenType.COLON, "[", 0, 0),
@@ -506,6 +514,9 @@ class TestParser(unittest.TestCase):
         self.assertEqual(parser._parse_exp(), expected_tree)
         self.assertEqual(len(parser.context_hints), 0)
         self.assertEqual(parser.current_token, EOF_TOKEN)
+        parser = Parser("(...)")
+        expected_tree = Vararg(Token(TokenType.ELLIPSIS, "...", 0, 0), has_parentheses=True)
+        self.assertEqual(parser._parse_exp(), expected_tree)
 
     def test_parse_table_expr(self):
         parser = Parser("{a}")
@@ -728,6 +739,15 @@ class TestParser(unittest.TestCase):
             pe.exception.hints,
             [Hint(Token(TokenType.COLON, ":", 0, 0), "invocation", "name")],
         )
+        parser = Parser("(a:b(1))")
+        expected_tree = ExpMethodInvocation(
+            Token(TokenType.NAME, "a", 0, 0),
+            self.parse_name("a"),
+            self.parse_name("b"),
+            [self.parse_number("1")],
+            has_parentheses=True,
+        )
+        self.assertEqual(parser._parse_exp(), expected_tree)
 
     def test_index_expr(self):
         parser = Parser("a[1]")

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -515,7 +515,9 @@ class TestParser(unittest.TestCase):
         self.assertEqual(len(parser.context_hints), 0)
         self.assertEqual(parser.current_token, EOF_TOKEN)
         parser = Parser("(...)")
-        expected_tree = Vararg(Token(TokenType.ELLIPSIS, "...", 0, 0), has_parentheses=True)
+        expected_tree = Vararg(
+            Token(TokenType.ELLIPSIS, "...", 0, 0), has_parentheses=True
+        )
         self.assertEqual(parser._parse_exp(), expected_tree)
 
     def test_parse_table_expr(self):

--- a/tumfl/AST/expression/exp_function_call.py
+++ b/tumfl/AST/expression/exp_function_call.py
@@ -15,7 +15,9 @@ class ExpFunctionCall(Expression):
         token: Token,
         function: Expression,
         arguments: Sequence[Expression],
+        has_parentheses: bool = False,
     ):
         super().__init__(token, "ExpFunctionCall")
         self.function: Expression = function
         self.arguments: list[Expression] = list(arguments)
+        self.has_parentheses: bool = has_parentheses

--- a/tumfl/AST/expression/exp_method_invocation.py
+++ b/tumfl/AST/expression/exp_method_invocation.py
@@ -18,8 +18,10 @@ class ExpMethodInvocation(Expression):
         function: Expression,
         method: Name,
         arguments: Sequence[Expression],
+        has_parentheses: bool = False,
     ):
         super().__init__(token, "ExpMethodInvocation")
         self.function: Expression = function
         self.method: Name = method
         self.arguments: list[Expression] = list(arguments)
+        self.has_parentheses: bool = has_parentheses

--- a/tumfl/AST/expression/vararg.py
+++ b/tumfl/AST/expression/vararg.py
@@ -8,8 +8,9 @@ from .expression import Expression
 class Vararg(Expression):
     """The vararg expression (...)"""
 
-    def __init__(self, token: Token) -> None:
+    def __init__(self, token: Token, has_parentheses: bool = False) -> None:
         super().__init__(token, "Vararg")
+        self.has_parentheses: bool = has_parentheses
 
     @staticmethod
     def from_token(token: Token) -> Vararg:

--- a/tumfl/formatter.py
+++ b/tumfl/formatter.py
@@ -279,7 +279,8 @@ class Formatter(BasicWalker[Retype]):
         return ["{", *self._format_args(node.fields), "}"]
 
     def visit_Vararg(self, node: Vararg) -> Retype:
-        unused(node)
+        if node.has_parentheses:
+            return ["(", "...", ")"]
         return ["..."]
 
     def visit_While(self, node: While) -> Retype:
@@ -422,9 +423,12 @@ class Formatter(BasicWalker[Retype]):
         return result
 
     def visit_ExpFunctionCall(self, node: ExpFunctionCall) -> Retype:
-        return self._format_var(node.function) + self._format_function_args(
+        result = self._format_var(node.function) + self._format_function_args(
             node.arguments
         )
+        if node.has_parentheses:
+            return ["(", *result, ")"]
+        return result
 
     def visit_ExpFunctionDefinition(self, node: ExpFunctionDefinition) -> Retype:
         return [
@@ -438,10 +442,12 @@ class Formatter(BasicWalker[Retype]):
 
     def visit_ExpMethodInvocation(self, node: ExpMethodInvocation) -> Retype:
         return [
+            *(("(",) if node.has_parentheses else ()),
             *self._format_var(node.function),
             ":",
             *self.visit(node.method),
             *self._format_function_args(node.arguments),
+            *((")",) if node.has_parentheses else ()),
         ]
 
     def visit_LocalFunctionDefinition(self, node: LocalFunctionDefinition) -> Retype:

--- a/tumfl/parser.py
+++ b/tumfl/parser.py
@@ -752,6 +752,10 @@ class Parser:
             remove_hint = True
             self._eat_token()
             var = self._parse_exp()
+            # In most cases, having extra parenthesis is not necessary, but for function calls and varargs,
+            # it is important to keep them, as they change the meaning of the expression
+            if isinstance(var, (Vararg, ExpFunctionCall, ExpMethodInvocation)):
+                var.has_parentheses = True
             self._eat_token(TokenType.R_PAREN)
         else:
             self._error("Unexpected variable", self.current_token)


### PR DESCRIPTION
Previously, there was no way to tell, if a function was wrapped in parentheses. This is important if a function or vararg returns a multires expression, since it will strip all but the first result.